### PR TITLE
Add serde deserialization over parsed documents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,6 +507,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-metal",
  "proptest",
+ "serde",
  "serde_json",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,6 +519,7 @@ dependencies = [
  "cc",
  "criterion",
  "metal-json",
+ "serde",
  "serde_json",
  "simd-json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ objc2-metal = "0.3"
 block2 = "0.6"
 dispatch2 = "0.3"
 memmap2 = "0.9"
+serde = { version = "1", optional = true }
 thiserror = "2"
 
 [features]
@@ -31,8 +32,11 @@ runtime-shaders = []
 cpu-reference = []
 # Per-kernel GPU timing via MTLCounterSampleBuffer (lands in M5).
 timing = []
+# Deserialize parsed Documents/Values into serde data models.
+serde = ["dep:serde"]
 
 [dev-dependencies]
+serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order", "arbitrary_precision"] }
 proptest = "1"
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,31 @@ fn main() -> Result<(), metal_json::Error> {
 }
 ```
 
+With the `serde` feature, you can deserialize the parsed document into a
+typed data model:
+
+```rust
+use metal_json::Parser;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct Payload {
+    name: String,
+    tags: Vec<f64>,
+}
+
+fn main() -> Result<(), metal_json::Error> {
+    let parser = Parser::new()?;
+    let payload: Payload = parser.parse_deserialize(br#"{"name":"meow","tags":[1,2.5]}"#)?;
+    assert_eq!(payload.tags[1], 2.5);
+    Ok(())
+}
+```
+
+`parse_deserialize` returns an owned value. If your struct borrows strings,
+parse to a `Document` first and call `doc.deserialize()` so the document can
+outlive the borrowed fields.
+
 `Parser` is reusable (device, pipeline states, and a buffer pool are built
 once); `Document` is self-contained and returns its buffers to the pool on
 drop. For repeated parsing without input copies, fill a parser-provided
@@ -88,9 +113,25 @@ modified for the duration of the parse — truncating a mapped file can
 - **macOS on Apple Silicon** (unified memory is the point: input bytes map
   into the GPU with `MTLBuffer bytesNoCopy`, output tapes live in shared
   storage — zero copies either way).
-- Xcode Metal toolchain for the AOT shader build
-  (`xcodebuild -downloadComponent MetalToolchain`), or build with
-  `--features runtime-shaders` to compile MSL at runtime instead.
+- For broad prebuilt binaries, build with `--features runtime-shaders` so
+  the shader source is compiled on the user's actual Metal device/runtime.
+  AOT metallibs are best for controlled deployments where the target GPU
+  family and macOS/Metal runtime are known.
+- Source builds without `runtime-shaders` require the Xcode Metal toolchain
+  for the AOT shader build (`xcodebuild -downloadComponent MetalToolchain`).
+
+## Feature flags
+
+- `runtime-shaders` — compile MSL at runtime instead of embedding an AOT
+  metallib. This is the preferred compatibility mode for distributed
+  prebuilt binaries and also supports `METAL_JSON_SHADER_DIR` hot reload
+  during shader development.
+- `cpu-reference` — scalar CPU oracle backend, mainly for testing and
+  backend parity work.
+- `timing` — per-kernel GPU timing helpers.
+- `serde` — deserialize parsed `Document`/`Value` cursors into serde data
+  models. This can avoid an intermediate `serde_json::Value` and skip manual
+  tape traversal, but it does not skip JSON validation/parsing itself.
 
 ## Architecture
 

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -10,10 +10,11 @@ publish = false
 # populate with `cargo run -p xtask -- fetch-data` / `gen-data`.
 
 [dependencies]
-metal-json = { path = "..", features = ["cpu-reference"] }
+metal-json = { path = "..", features = ["cpu-reference", "serde"] }
 
 [dev-dependencies]
 criterion = "0.8"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 simd-json = "0.17"
 
@@ -22,4 +23,8 @@ cc = { version = "1", features = ["parallel"] }
 
 [[bench]]
 name = "compare"
+harness = false
+
+[[bench]]
+name = "serde_compare"
 harness = false

--- a/bench/benches/serde_compare.rs
+++ b/bench/benches/serde_compare.rs
@@ -1,0 +1,292 @@
+//! serde deserialization comparison: metal-json (parse-to-tape + tape-walking
+//! `Deserializer`) vs serde_json, into the same typed Rust struct.
+//!
+//! Typed deserialization needs a fixed schema, so unlike `compare.rs` this
+//! bench does not walk the datasets under `data/bench` — it generates one
+//! deterministic synthetic corpus in code (a ~4 MiB JSON array of objects;
+//! see [`generate_corpus`]) and parses byte-identical input four ways:
+//!
+//! - **metal-json / borrowed**: `parse_aligned` from a caller-held
+//!   [`AlignedInput`] (the zero-copy input path, as in `compare.rs`), then
+//!   `Document::deserialize` into a struct with `&str` fields borrowed
+//!   straight from the document's string buffer — no per-string allocation.
+//!   The timed closure covers parse + deserialize; the records (cheap: no
+//!   owned strings) are dropped inside, the `Document` outside
+//!   (`iter_with_large_drop`), mirroring `compare.rs`.
+//! - **metal-json / owned**: `Parser::parse_deserialize` into the same
+//!   struct shape with owned `String` fields — the convenience one-call API.
+//! - **serde_json / owned**: `from_slice` into the owned struct — the
+//!   conventional baseline.
+//! - **serde_json / borrowed**: `from_str` into the borrowed struct
+//!   (serde_json can borrow escape-free strings from `&str` input; the
+//!   generated strings contain no escapes).
+//!
+//! The backend follows `compare.rs`: `METAL_JSON_BENCH_BACKEND=gpu|cpu-
+//! reference` when set; otherwise the GPU when a probe parse succeeds, with
+//! a fallback to `Backend::CpuReference` so the bench always runs.
+//!
+//! An UNTIMED check asserts all four contenders produce identical record
+//! checksums (id XOR / string bytes / score-bits XOR), proving the timed
+//! closures do equivalent work. `Throughput::Bytes(document_len)`.
+
+use std::fmt::Write as _;
+use std::hint::black_box;
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use metal_json::{AlignedInput, Backend, Parser, ParserOptions};
+use serde::Deserialize;
+
+/// Target corpus size in bytes (~4 MiB; generation overshoots by at most
+/// one record).
+const TARGET_BYTES: usize = 4 * 1024 * 1024;
+
+/// The owned struct shape: every string field allocates.
+#[derive(Debug, Deserialize)]
+struct EventOwned {
+    id: u64,
+    user: String,
+    message: String,
+    score: f64,
+    active: bool,
+    tags: Vec<String>,
+}
+
+/// The borrowed struct shape: `&str` fields point into the deserializer's
+/// backing buffer (metal-json's string buffer / serde_json's `&str` input).
+#[derive(Debug, Deserialize)]
+struct EventBorrowed<'a> {
+    id: u64,
+    #[serde(borrow)]
+    user: &'a str,
+    #[serde(borrow)]
+    message: &'a str,
+    score: f64,
+    active: bool,
+    #[serde(borrow)]
+    tags: Vec<&'a str>,
+}
+
+/// Order-independent record checksum used by the untimed equivalence check:
+/// XOR of ids (each offset by the `active` flag), total string bytes, XOR of
+/// raw score bits — every field of the structs feeds the checksum.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct Checksum {
+    id_xor: u64,
+    string_bytes: u64,
+    score_xor: u64,
+}
+
+fn checksum_owned(events: &[EventOwned]) -> Checksum {
+    let mut c = Checksum::default();
+    for e in events {
+        c.id_xor ^= e.id + u64::from(e.active);
+        c.string_bytes += (e.user.len() + e.message.len()) as u64;
+        c.string_bytes += e.tags.iter().map(|t| t.len() as u64).sum::<u64>();
+        c.score_xor ^= e.score.to_bits();
+    }
+    c
+}
+
+fn checksum_borrowed(events: &[EventBorrowed<'_>]) -> Checksum {
+    let mut c = Checksum::default();
+    for e in events {
+        c.id_xor ^= e.id + u64::from(e.active);
+        c.string_bytes += (e.user.len() + e.message.len()) as u64;
+        c.string_bytes += e.tags.iter().map(|t| t.len() as u64).sum::<u64>();
+        c.score_xor ^= e.score.to_bits();
+    }
+    c
+}
+
+/// Deterministic xorshift64* PRNG — no dependency, identical corpus on every
+/// run and every machine.
+struct Rng(u64);
+
+impl Rng {
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.0 = x;
+        x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    }
+}
+
+/// Generate a deterministic JSON array of objects, at least [`TARGET_BYTES`]
+/// long. Strings are alphanumeric words (no escapes), so serde_json's
+/// borrowed path can borrow every string from the input.
+fn generate_corpus() -> String {
+    const WORDS: &[&str] = &[
+        "alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel", "india",
+        "juliett", "kilo", "lima", "mike", "november", "oscar", "papa", "quebec", "romeo",
+        "sierra", "tango",
+    ];
+    let mut rng = Rng(0x6d65_7461_6c2d_6a73); // "metal-js"
+    let mut out = String::with_capacity(TARGET_BYTES + 256);
+    out.push('[');
+    let mut id: u64 = 0;
+    while out.len() < TARGET_BYTES {
+        if id > 0 {
+            out.push(',');
+        }
+        let user = WORDS[(rng.next() % WORDS.len() as u64) as usize];
+        write!(
+            out,
+            r#"{{"id":{id},"user":"{user}_{}","message":""#,
+            rng.next() % 10_000
+        )
+        .expect("write to String");
+        // 4–11 space-separated words; spaces are legal unescaped in JSON.
+        for w in 0..4 + rng.next() % 8 {
+            if w > 0 {
+                out.push(' ');
+            }
+            out.push_str(WORDS[(rng.next() % WORDS.len() as u64) as usize]);
+        }
+        write!(
+            out,
+            r#"","score":{}.{:02},"active":{},"tags":["#,
+            rng.next() % 1_000,
+            rng.next() % 100,
+            rng.next().is_multiple_of(2),
+        )
+        .expect("write to String");
+        for t in 0..1 + rng.next() % 4 {
+            if t > 0 {
+                out.push(',');
+            }
+            write!(
+                out,
+                r#""{}""#,
+                WORDS[(rng.next() % WORDS.len() as u64) as usize]
+            )
+            .expect("write to String");
+        }
+        out.push_str("]}");
+        id += 1;
+    }
+    out.push(']');
+    out
+}
+
+/// Build the metal-json parser: honor `METAL_JSON_BENCH_BACKEND` when set
+/// (as in `compare.rs`); otherwise probe the GPU and fall back to the CPU
+/// oracle so the bench runs everywhere.
+fn metal_parser() -> Parser {
+    let requested = match std::env::var("METAL_JSON_BENCH_BACKEND").as_deref() {
+        Ok("cpu-reference" | "cpu_reference" | "cpu") => Some(Backend::CpuReference),
+        Ok("gpu") => Some(Backend::Gpu),
+        Err(_) => None,
+        Ok(other) => {
+            eprintln!(
+                "METAL_JSON_BENCH_BACKEND={other:?} not recognized (want gpu|cpu-reference); \
+                 auto-selecting"
+            );
+            None
+        }
+    };
+    for backend in requested.map_or(vec![Backend::Gpu, Backend::CpuReference], |b| vec![b]) {
+        // ParserOptions is #[non_exhaustive]: construct via Default, then set.
+        let mut opts = ParserOptions::default();
+        opts.backend = backend;
+        // Probe parse: catches a missing/paravirtual Metal device.
+        match Parser::with_options(opts).and_then(|p| p.parse(b"[0]").map(|_| p)) {
+            Ok(parser) => {
+                eprintln!("metal-json contenders active (backend: {backend:?})");
+                return parser;
+            }
+            Err(err) => eprintln!("metal-json backend {backend:?} unavailable: {err}"),
+        }
+    }
+    panic!("no usable metal-json backend (GPU probe failed and CpuReference unavailable)");
+}
+
+fn bench_serde(c: &mut Criterion) {
+    let corpus = generate_corpus();
+    let bytes = corpus.as_bytes();
+    let len = bytes.len() as u64;
+    let parser = metal_parser();
+    let aligned = AlignedInput::from_slice(bytes);
+
+    // UNTIMED verification, once: all four contenders must produce the same
+    // record count and checksum — proof the timed closures do the same work.
+    let expected = {
+        let owned: Vec<EventOwned> =
+            serde_json::from_slice(bytes).expect("serde_json owned parse failed");
+        let expected = checksum_owned(&owned);
+        let borrowed: Vec<EventBorrowed> =
+            serde_json::from_str(&corpus).expect("serde_json borrowed parse failed");
+        assert_eq!(checksum_borrowed(&borrowed), expected);
+        let owned: Vec<EventOwned> = parser
+            .parse_deserialize(bytes)
+            .expect("metal-json owned parse failed");
+        assert_eq!(checksum_owned(&owned), expected);
+        let doc = parser
+            .parse_aligned(&aligned)
+            .expect("metal-json parse failed");
+        let borrowed: Vec<EventBorrowed> =
+            doc.deserialize().expect("metal-json borrowed parse failed");
+        assert_eq!(checksum_borrowed(&borrowed), expected);
+        eprintln!(
+            "synthetic corpus: {} bytes, {} records; checksums verified across all contenders",
+            bytes.len(),
+            borrowed.len()
+        );
+        expected
+    };
+
+    let mut group = c.benchmark_group("serde_synthetic_4m");
+    group.throughput(Throughput::Bytes(len));
+    group.sample_size(60);
+
+    // metal-json, zero-copy: parse from the aligned input, deserialize with
+    // borrowed strings. Dropping the records is cheap (no owned strings) and
+    // stays inside the timed region; the Document drop (returning pooled
+    // buffers) is outside, as in compare.rs.
+    group.bench_function("metal-json-borrowed", |b| {
+        b.iter_with_large_drop(|| {
+            let doc = parser
+                .parse_aligned(black_box(&aligned))
+                .expect("metal-json parse failed");
+            let events: Vec<EventBorrowed> =
+                doc.deserialize().expect("metal-json deserialize failed");
+            black_box(events.len() ^ events[0].id as usize);
+            drop(events);
+            doc // dropped by criterion, outside the timed region
+        });
+    });
+
+    // metal-json, owned: the one-call convenience API (parse + deserialize
+    // with String fields). Vec drop (many Strings) is outside timing,
+    // matching serde-json-owned below.
+    group.bench_function("metal-json-owned", |b| {
+        b.iter_with_large_drop(|| {
+            parser
+                .parse_deserialize::<Vec<EventOwned>>(black_box(bytes))
+                .expect("metal-json parse_deserialize failed")
+        });
+    });
+
+    // serde_json into the owned struct: the conventional baseline.
+    group.bench_function("serde-json-owned", |b| {
+        b.iter_with_large_drop(|| {
+            serde_json::from_slice::<Vec<EventOwned>>(black_box(bytes))
+                .expect("serde_json parse failed")
+        });
+    });
+
+    // serde_json borrowing from &str input (possible here: no escapes).
+    group.bench_function("serde-json-borrowed", |b| {
+        b.iter_with_large_drop(|| {
+            serde_json::from_str::<Vec<EventBorrowed>>(black_box(corpus.as_str()))
+                .expect("serde_json parse failed")
+        });
+    });
+
+    group.finish();
+    black_box(expected);
+}
+
+criterion_group!(benches, bench_serde);
+criterion_main!(benches);

--- a/src/document.rs
+++ b/src/document.rs
@@ -72,6 +72,22 @@ impl Document {
     pub fn strings(&self) -> &StringBuffer {
         &self.strings
     }
+
+    /// Deserialize the root value into a serde data model.
+    ///
+    /// The returned value may borrow strings from this [`Document`], so the
+    /// document must outlive any borrowed fields in `T`.
+    ///
+    /// # Errors
+    ///
+    /// If the root value's shape or scalar values do not match `T`.
+    #[cfg(feature = "serde")]
+    pub fn deserialize<'de, T>(&'de self) -> crate::serde::Result<T>
+    where
+        T: ::serde::Deserialize<'de>,
+    {
+        crate::serde::from_document(self)
+    }
 }
 
 #[cfg(test)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -87,6 +87,12 @@ pub enum Error {
     /// Filesystem error (e.g. `parse_file` mmap).
     #[error(transparent)]
     Io(#[from] std::io::Error),
+
+    /// The parsed document could not be materialized as the requested
+    /// serde data model.
+    #[cfg(feature = "serde")]
+    #[error(transparent)]
+    Deserialize(#[from] crate::serde::DeserializeError),
 }
 
 /// Fine-grained classification for [`Error::Syntax`].

--- a/src/gpu/timing.rs
+++ b/src/gpu/timing.rs
@@ -8,8 +8,8 @@
 //! patches, tape copy-out)?
 //!
 //! With the feature enabled, every [`GpuPipeline::run`]
-//! (and the `Parser::parse` copy-out around it) records one [`Phase`] per
-//! pipeline segment into a thread-local; [`take_parse_timings`] hands the
+//! (and the `Parser::parse` copy-out around it) records one `Phase` per
+//! pipeline segment into a thread-local; `take_parse_timings` hands the
 //! finished list to the caller (see `examples/parse_breakdown.rs`).
 //! Without the feature every helper is an inlined no-op and the pipeline
 //! pays nothing.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,8 @@ pub mod gpu;
 pub mod metal;
 pub mod parser;
 pub mod pool;
+#[cfg(feature = "serde")]
+pub mod serde;
 pub mod stage;
 pub mod tape;
 pub mod value;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,10 @@
 //! - `cpu-reference` — scalar CPU oracle backend (M1); when enabled it is
 //!   also the *default*-backend fallback on machines without Metal.
 //! - `timing` — per-kernel GPU timing via `MTLCounterSampleBuffer` (M5).
+//! - `serde` — deserialize parsed [`Document`]/[`Value`] cursors into serde
+//!   data models (the `serde` module, `Document::deserialize`,
+//!   `Value::deserialize`, `Parser::parse_deserialize`); avoids an
+//!   intermediate `serde_json::Value` but does not skip JSON parsing itself.
 
 mod error;
 mod input;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -251,6 +251,27 @@ impl Parser {
         }
     }
 
+    /// Parse a JSON document and deserialize it into an owned serde data
+    /// model.
+    ///
+    /// This convenience path returns only `T`, so `T` must own its data.
+    /// Use [`Document::deserialize`](crate::Document::deserialize) or
+    /// [`crate::serde::from_document`] when `T` contains borrowed string
+    /// fields.
+    ///
+    /// # Errors
+    ///
+    /// Any parse failure from [`parse`](Self::parse), or a serde
+    /// deserialization error if the parsed document does not match `T`.
+    #[cfg(feature = "serde")]
+    pub fn parse_deserialize<T>(&self, json: &[u8]) -> Result<T>
+    where
+        T: ::serde::de::DeserializeOwned,
+    {
+        let doc = self.parse(json)?;
+        Ok(crate::serde::from_document(&doc)?)
+    }
+
     /// Parse from a caller-held [`AlignedInput`] — the **zero-copy** input
     /// path: the input pages are wrapped with `MTLBuffer bytesNoCopy` and
     /// read by the GPU in place. Build the `AlignedInput` once, parse from

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -2,18 +2,25 @@
 //!
 //! This module does not parse JSON text. It materializes Rust data models
 //! from the tape/string buffers already produced by [`Parser`](crate::Parser).
-//! Keeping the [`Document`](crate::Document) alive lets serde borrow string
+//! Keeping the [`Document`] alive lets serde borrow string
 //! fields directly from the document.
+//!
+//! JSON integers within the `i64`/`u64` range deserialize into `i128`/
+//! `u128` targets exactly (including values above 2⁵³). Integers beyond
+//! that range were stored as `f64` at parse time — same as simdjson — so
+//! `i128`/`u128` targets reject them with an invalid-type error, unlike
+//! `serde_json`, which parses the full 128-bit range.
 
 use core::fmt;
 
 use ::serde::Deserializer as _;
+use ::serde::de::value::BorrowedStrDeserializer;
 use ::serde::de::{
-    self, DeserializeSeed, EnumAccess, Error as _, IntoDeserializer, MapAccess, SeqAccess,
-    VariantAccess, Visitor,
+    self, DeserializeSeed, EnumAccess, Error as _, MapAccess, SeqAccess, VariantAccess, Visitor,
 };
 
 use crate::document::Document;
+use crate::tape::CONTAINER_COUNT_MAX;
 use crate::value::{ArrayIter, ObjectIter, Value, ValueKind};
 
 /// Result type for serde materialization from a parsed document.
@@ -127,10 +134,15 @@ fn bool_value(value: Value<'_>) -> Result<bool> {
         .ok_or_else(|| invalid_tape(value, "boolean payload"))
 }
 
-fn container_len(value: Value<'_>) -> Result<usize> {
-    value
-        .len()
-        .ok_or_else(|| invalid_tape(value, "container length"))
+/// `Some(exact)` size hint, or `None` when the stored count is saturated
+/// at [`CONTAINER_COUNT_MAX`] ("this many or more") — serde caps capacity
+/// hints anyway, so a pre-walk of a huge container just to count it would
+/// be a wasted O(n) tape pass.
+fn container_hint(value: Value<'_>) -> Result<Option<usize>> {
+    let count = value
+        .raw_container_count()
+        .ok_or_else(|| invalid_tape(value, "container length"))?;
+    Ok((count < CONTAINER_COUNT_MAX).then_some(count as usize))
 }
 
 impl<'de> de::Deserializer<'de> for Value<'de> {
@@ -199,23 +211,37 @@ impl<'de> de::Deserializer<'de> for Value<'de> {
         }
     }
 
-    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value>
+    fn deserialize_tuple<V>(self, len: usize, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        self.deserialize_seq(visitor)
+        if self.kind() != ValueKind::Array {
+            return Err(invalid_type(self, "array"));
+        }
+        let mut access = ArrayAccess::new(self)?;
+        let tuple = visitor.visit_seq(&mut access)?;
+        // Tuple visitors stop after `len` elements, so extras would be
+        // silently dropped; reject them like serde_json does.
+        if access.iter.next().is_none() {
+            Ok(tuple)
+        } else {
+            Err(DeserializeError::invalid_length(
+                self.len().unwrap_or(len),
+                &"fewer elements in array",
+            ))
+        }
     }
 
     fn deserialize_tuple_struct<V>(
         self,
         _name: &'static str,
-        _len: usize,
+        len: usize,
         visitor: V,
     ) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        self.deserialize_seq(visitor)
+        self.deserialize_tuple(len, visitor)
     }
 
     fn deserialize_map<V>(self, visitor: V) -> Result<V::Value>
@@ -238,7 +264,13 @@ impl<'de> de::Deserializer<'de> for Value<'de> {
     where
         V: Visitor<'de>,
     {
-        self.deserialize_map(visitor)
+        // Like serde_json, structs accept an array of positional fields in
+        // declaration order as well as the usual keyed object.
+        match self.kind() {
+            ValueKind::Object => visitor.visit_map(ObjectAccess::new(self)?),
+            ValueKind::Array => visitor.visit_seq(ArrayAccess::new(self)?),
+            _ => Err(invalid_type(self, "object or array")),
+        }
     }
 
     fn deserialize_enum<V>(
@@ -251,7 +283,9 @@ impl<'de> de::Deserializer<'de> for Value<'de> {
         V: Visitor<'de>,
     {
         match self.kind() {
-            ValueKind::String => visitor.visit_enum(string_value(self)?.into_deserializer()),
+            ValueKind::String => {
+                visitor.visit_enum(BorrowedStrDeserializer::new(string_value(self)?))
+            }
             ValueKind::Object => {
                 if self.len() != Some(1) {
                     return Err(DeserializeError::custom(
@@ -310,21 +344,90 @@ impl<'de> de::Deserializer<'de> for Value<'de> {
         visitor.visit_unit()
     }
 
+    // Direct happy paths for the common scalar requests: one tag check,
+    // then the matching visit. The mismatch fallback is `deserialize_any`,
+    // which preserves its cross-kind semantics exactly (e.g. an `f64`
+    // target still sees `visit_i64`/`visit_u64` for integer tape values,
+    // so serde widens; wrong kinds get the visitor's own rejection).
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        if self.kind() == ValueKind::Bool {
+            visitor.visit_bool(bool_value(self)?)
+        } else {
+            self.deserialize_any(visitor)
+        }
+    }
+
+    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        if self.kind() == ValueKind::Int64 {
+            visitor.visit_i64(i64_value(self)?)
+        } else {
+            self.deserialize_any(visitor)
+        }
+    }
+
+    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        if self.kind() == ValueKind::UInt64 {
+            visitor.visit_u64(u64_value(self)?)
+        } else {
+            self.deserialize_any(visitor)
+        }
+    }
+
+    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        if self.kind() == ValueKind::Double {
+            visitor.visit_f64(f64_value(self)?)
+        } else {
+            self.deserialize_any(visitor)
+        }
+    }
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        if self.kind() == ValueKind::String {
+            visitor.visit_borrowed_str(string_value(self)?)
+        } else {
+            self.deserialize_any(visitor)
+        }
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
     ::serde::forward_to_deserialize_any! {
-        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        i8 i16 i32 i128 u8 u16 u32 u128 f32 char
     }
 }
 
 struct ArrayAccess<'de> {
     iter: ArrayIter<'de>,
-    remaining: usize,
+    /// Exact elements left, or `None` when the stored count is saturated.
+    remaining: Option<usize>,
 }
 
 impl<'de> ArrayAccess<'de> {
     fn new(value: Value<'de>) -> Result<Self> {
         Ok(Self {
             iter: value.elements(),
-            remaining: container_len(value)?,
+            remaining: container_hint(value)?,
         })
     }
 }
@@ -339,19 +442,20 @@ impl<'de> SeqAccess<'de> for ArrayAccess<'de> {
         let Some(value) = self.iter.next() else {
             return Ok(None);
         };
-        self.remaining = self.remaining.saturating_sub(1);
+        self.remaining = self.remaining.map(|n| n.saturating_sub(1));
         seed.deserialize(value).map(Some)
     }
 
     fn size_hint(&self) -> Option<usize> {
-        Some(self.remaining)
+        self.remaining
     }
 }
 
 struct ObjectAccess<'de> {
     iter: ObjectIter<'de>,
     pending_value: Option<Value<'de>>,
-    remaining: usize,
+    /// Exact members left, or `None` when the stored count is saturated.
+    remaining: Option<usize>,
 }
 
 impl<'de> ObjectAccess<'de> {
@@ -359,7 +463,7 @@ impl<'de> ObjectAccess<'de> {
         Ok(Self {
             iter: value.entries(),
             pending_value: None,
-            remaining: container_len(value)?,
+            remaining: container_hint(value)?,
         })
     }
 }
@@ -375,8 +479,8 @@ impl<'de> MapAccess<'de> for ObjectAccess<'de> {
             return Ok(None);
         };
         self.pending_value = Some(value);
-        self.remaining = self.remaining.saturating_sub(1);
-        seed.deserialize(key.into_deserializer()).map(Some)
+        self.remaining = self.remaining.map(|n| n.saturating_sub(1));
+        seed.deserialize(MapKeyDeserializer { key }).map(Some)
     }
 
     fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value>
@@ -390,7 +494,88 @@ impl<'de> MapAccess<'de> for ObjectAccess<'de> {
     }
 
     fn size_hint(&self) -> Option<usize> {
-        Some(self.remaining)
+        self.remaining
+    }
+}
+
+/// Deserializer for object keys and enum variant names.
+///
+/// Keys are always strings on the tape, normally delivered with
+/// `visit_borrowed_str` — `BorrowedStrDeserializer` rather than
+/// `key.into_deserializer()`, which drops the 'de lifetime via `visit_str`,
+/// so keys can be deserialized as `&'de str` borrowed from the document.
+/// But, like serde_json's map-key deserializer, integer and bool targets
+/// parse the key text (JSON object keys are always quoted, so `{"1":...}`
+/// is how an integer-keyed map serializes), and newtype-struct keys unwrap
+/// to the inner type.
+struct MapKeyDeserializer<'de> {
+    key: &'de str,
+}
+
+/// `deserialize_*` that parses the key text for the requested target,
+/// falling back to the borrowed string (and the visitor's own type error)
+/// when the key does not parse.
+macro_rules! deserialize_parsed_key {
+    ($($method:ident => $visit:ident)*) => {
+        $(fn $method<V>(self, visitor: V) -> Result<V::Value>
+        where
+            V: Visitor<'de>,
+        {
+            match self.key.parse() {
+                Ok(parsed) => visitor.$visit(parsed),
+                Err(_) => visitor.visit_borrowed_str(self.key),
+            }
+        })*
+    };
+}
+
+impl<'de> de::Deserializer<'de> for MapKeyDeserializer<'de> {
+    type Error = DeserializeError;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_borrowed_str(self.key)
+    }
+
+    deserialize_parsed_key! {
+        deserialize_bool => visit_bool
+        deserialize_i8 => visit_i8
+        deserialize_i16 => visit_i16
+        deserialize_i32 => visit_i32
+        deserialize_i64 => visit_i64
+        deserialize_i128 => visit_i128
+        deserialize_u8 => visit_u8
+        deserialize_u16 => visit_u16
+        deserialize_u32 => visit_u32
+        deserialize_u64 => visit_u64
+        deserialize_u128 => visit_u128
+    }
+
+    fn deserialize_newtype_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        // BorrowedStrDeserializer is a unit-variant-only EnumAccess.
+        visitor.visit_enum(BorrowedStrDeserializer::new(self.key))
+    }
+
+    ::serde::forward_to_deserialize_any! {
+        f32 f64 char str string bytes byte_buf option unit unit_struct seq
+        tuple tuple_struct map struct identifier ignored_any
     }
 }
 
@@ -407,7 +592,10 @@ impl<'de> EnumAccess<'de> for ExternalEnum<'de> {
     where
         V: DeserializeSeed<'de>,
     {
-        let variant = seed.deserialize(self.variant.into_deserializer())?;
+        // MapKeyDeserializer for the same reasons as map keys: variant
+        // identifiers may be deserialized as `&'de str`, and serde_json
+        // parses non-string variant keys (e.g. integer-tagged enums).
+        let variant = seed.deserialize(MapKeyDeserializer { key: self.variant })?;
         Ok((variant, ExternalVariant { value: self.value }))
     }
 }
@@ -434,17 +622,134 @@ impl<'de> VariantAccess<'de> for ExternalVariant<'de> {
         seed.deserialize(self.value)
     }
 
-    fn tuple_variant<V>(self, _len: usize, visitor: V) -> Result<V::Value>
+    fn tuple_variant<V>(self, len: usize, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        self.value.deserialize_seq(visitor)
+        // deserialize_tuple, not deserialize_seq, so extra elements are
+        // rejected here too.
+        self.value.deserialize_tuple(len, visitor)
     }
 
     fn struct_variant<V>(self, _fields: &'static [&'static str], visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        self.value.deserialize_map(visitor)
+        // Same object-or-positional-array acceptance as deserialize_struct.
+        match self.value.kind() {
+            ValueKind::Object => visitor.visit_map(ObjectAccess::new(self.value)?),
+            ValueKind::Array => visitor.visit_seq(ArrayAccess::new(self.value)?),
+            _ => Err(invalid_type(self.value, "object or array")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tape::{
+        StringBuffer, TAG_END_ARRAY, TAG_END_OBJECT, TAG_START_ARRAY, TAG_START_OBJECT, TapeBuffer,
+        int64_bits, make_close, make_final_root, make_int64_marker, make_open, make_root,
+        make_string, make_true,
+    };
+
+    // -----------------------------------------------------------------
+    // size_hint bookkeeping: exact counts decrement to zero, saturated
+    // counts ("this many or more") yield no hint at all
+    // -----------------------------------------------------------------
+
+    /// `[10, 20, 30]` whose open word stores `count` (hand-built like the
+    /// saturated-count tests in `value.rs`, since only a >0xFFFFFF-element
+    /// GPU tape would store a saturated count for real).
+    fn array_doc(count: u32) -> Document {
+        let mut tape = TapeBuffer::new();
+        tape.push(0); // root placeholder
+        let open = tape.push(0);
+        for v in [10i64, 20, 30] {
+            tape.push(make_int64_marker());
+            tape.push(int64_bits(v));
+        }
+        let close = tape.push(make_close(TAG_END_ARRAY, open as u32));
+        tape.set(open, make_open(TAG_START_ARRAY, (close + 1) as u32, count));
+        let final_index = tape.push(make_final_root());
+        tape.set(0, make_root(final_index as u64));
+        Document::from_parts(tape, StringBuffer::new())
+    }
+
+    /// `{"p":true,"q":true}` whose open word stores `count`.
+    fn object_doc(count: u32) -> Document {
+        let mut tape = TapeBuffer::new();
+        let mut strings = StringBuffer::new();
+        tape.push(0); // root placeholder
+        let open = tape.push(0);
+        for key in ["p", "q"] {
+            let offset = strings.append_record(key.as_bytes());
+            tape.push(make_string(offset));
+            tape.push(make_true());
+        }
+        let close = tape.push(make_close(TAG_END_OBJECT, open as u32));
+        tape.set(open, make_open(TAG_START_OBJECT, (close + 1) as u32, count));
+        let final_index = tape.push(make_final_root());
+        tape.set(0, make_root(final_index as u64));
+        Document::from_parts(tape, strings)
+    }
+
+    /// Visitor recording the access's `size_hint` before the first item
+    /// and after every yielded item, draining the container.
+    struct HintRecorder;
+
+    impl<'de> Visitor<'de> for HintRecorder {
+        type Value = Vec<Option<usize>>;
+
+        fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("a container")
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> core::result::Result<Self::Value, A::Error>
+        where
+            A: SeqAccess<'de>,
+        {
+            let mut hints = vec![seq.size_hint()];
+            while seq.next_element::<de::IgnoredAny>()?.is_some() {
+                hints.push(seq.size_hint());
+            }
+            Ok(hints)
+        }
+
+        fn visit_map<A>(self, mut map: A) -> core::result::Result<Self::Value, A::Error>
+        where
+            A: MapAccess<'de>,
+        {
+            let mut hints = vec![map.size_hint()];
+            while map
+                .next_entry::<de::IgnoredAny, de::IgnoredAny>()?
+                .is_some()
+            {
+                hints.push(map.size_hint());
+            }
+            Ok(hints)
+        }
+    }
+
+    #[test]
+    fn exact_counts_give_size_hints_that_count_down_per_item() {
+        let doc = array_doc(3);
+        let hints = doc.root().deserialize_any(HintRecorder).expect("seq");
+        assert_eq!(hints, [Some(3), Some(2), Some(1), Some(0)]);
+
+        let doc = object_doc(2);
+        let hints = doc.root().deserialize_any(HintRecorder).expect("map");
+        assert_eq!(hints, [Some(2), Some(1), Some(0)]);
+    }
+
+    #[test]
+    fn saturated_counts_give_no_size_hint() {
+        let doc = array_doc(CONTAINER_COUNT_MAX);
+        let hints = doc.root().deserialize_any(HintRecorder).expect("seq");
+        assert_eq!(hints, [None, None, None, None]);
+
+        let doc = object_doc(CONTAINER_COUNT_MAX);
+        let hints = doc.root().deserialize_any(HintRecorder).expect("map");
+        assert_eq!(hints, [None, None, None]);
     }
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -218,18 +218,7 @@ impl<'de> de::Deserializer<'de> for Value<'de> {
         if self.kind() != ValueKind::Array {
             return Err(invalid_type(self, "array"));
         }
-        let mut access = ArrayAccess::new(self)?;
-        let tuple = visitor.visit_seq(&mut access)?;
-        // Tuple visitors stop after `len` elements, so extras would be
-        // silently dropped; reject them like serde_json does.
-        if access.iter.next().is_none() {
-            Ok(tuple)
-        } else {
-            Err(DeserializeError::invalid_length(
-                self.len().unwrap_or(len),
-                &"fewer elements in array",
-            ))
-        }
+        visit_seq_exact(self, len, visitor)
     }
 
     fn deserialize_tuple_struct<V>(
@@ -258,7 +247,7 @@ impl<'de> de::Deserializer<'de> for Value<'de> {
     fn deserialize_struct<V>(
         self,
         _name: &'static str,
-        _fields: &'static [&'static str],
+        fields: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value>
     where
@@ -268,7 +257,7 @@ impl<'de> de::Deserializer<'de> for Value<'de> {
         // declaration order as well as the usual keyed object.
         match self.kind() {
             ValueKind::Object => visitor.visit_map(ObjectAccess::new(self)?),
-            ValueKind::Array => visitor.visit_seq(ArrayAccess::new(self)?),
+            ValueKind::Array => visit_seq_exact(self, fields.len(), visitor),
             _ => Err(invalid_type(self, "object or array")),
         }
     }
@@ -414,6 +403,26 @@ impl<'de> de::Deserializer<'de> for Value<'de> {
 
     ::serde::forward_to_deserialize_any! {
         i8 i16 i32 i128 u8 u16 u32 u128 f32 char
+    }
+}
+
+/// Drive `visitor.visit_seq` over `value`'s elements and reject any the
+/// visitor did not consume. Tuple and positional-struct visitors stop after
+/// their declared arity, so extras would otherwise be silently dropped;
+/// serde_json rejects them when it expects the closing `]`.
+fn visit_seq_exact<'de, V>(value: Value<'de>, len: usize, visitor: V) -> Result<V::Value>
+where
+    V: Visitor<'de>,
+{
+    let mut access = ArrayAccess::new(value)?;
+    let out = visitor.visit_seq(&mut access)?;
+    if access.iter.next().is_none() {
+        Ok(out)
+    } else {
+        Err(DeserializeError::invalid_length(
+            value.len().unwrap_or(len),
+            &"fewer elements in array",
+        ))
     }
 }
 
@@ -631,14 +640,14 @@ impl<'de> VariantAccess<'de> for ExternalVariant<'de> {
         self.value.deserialize_tuple(len, visitor)
     }
 
-    fn struct_variant<V>(self, _fields: &'static [&'static str], visitor: V) -> Result<V::Value>
+    fn struct_variant<V>(self, fields: &'static [&'static str], visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
         // Same object-or-positional-array acceptance as deserialize_struct.
         match self.value.kind() {
             ValueKind::Object => visitor.visit_map(ObjectAccess::new(self.value)?),
-            ValueKind::Array => visitor.visit_seq(ArrayAccess::new(self.value)?),
+            ValueKind::Array => visit_seq_exact(self.value, fields.len(), visitor),
             _ => Err(invalid_type(self.value, "object or array")),
         }
     }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,450 @@
+//! serde deserialization over parsed metal-json documents.
+//!
+//! This module does not parse JSON text. It materializes Rust data models
+//! from the tape/string buffers already produced by [`Parser`](crate::Parser).
+//! Keeping the [`Document`](crate::Document) alive lets serde borrow string
+//! fields directly from the document.
+
+use core::fmt;
+
+use ::serde::Deserializer as _;
+use ::serde::de::{
+    self, DeserializeSeed, EnumAccess, Error as _, IntoDeserializer, MapAccess, SeqAccess,
+    VariantAccess, Visitor,
+};
+
+use crate::document::Document;
+use crate::value::{ArrayIter, ObjectIter, Value, ValueKind};
+
+/// Result type for serde materialization from a parsed document.
+pub type Result<T> = core::result::Result<T, DeserializeError>;
+
+/// serde deserialization error produced while walking a parsed document.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeserializeError {
+    message: String,
+}
+
+impl DeserializeError {
+    /// The human-readable error message.
+    #[must_use]
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl fmt::Display for DeserializeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for DeserializeError {}
+
+impl de::Error for DeserializeError {
+    fn custom<T>(msg: T) -> Self
+    where
+        T: fmt::Display,
+    {
+        Self {
+            message: msg.to_string(),
+        }
+    }
+}
+
+/// Deserialize the root value of `document`.
+///
+/// `T` may borrow strings from `document`.
+pub fn from_document<'de, T>(document: &'de Document) -> Result<T>
+where
+    T: ::serde::Deserialize<'de>,
+{
+    from_value(document.root())
+}
+
+/// Deserialize `value`.
+///
+/// `T` may borrow strings from the value's backing document.
+pub fn from_value<'de, T>(value: Value<'de>) -> Result<T>
+where
+    T: ::serde::Deserialize<'de>,
+{
+    T::deserialize(value)
+}
+
+fn kind_name(kind: ValueKind) -> &'static str {
+    match kind {
+        ValueKind::Object => "object",
+        ValueKind::Array => "array",
+        ValueKind::String => "string",
+        ValueKind::Int64 | ValueKind::UInt64 | ValueKind::Double => "number",
+        ValueKind::Bool => "boolean",
+        ValueKind::Null => "null",
+    }
+}
+
+fn invalid_type(value: Value<'_>, expected: &'static str) -> DeserializeError {
+    DeserializeError::custom(format!(
+        "invalid type: {}, expected {expected}",
+        kind_name(value.kind())
+    ))
+}
+
+fn invalid_tape(value: Value<'_>, expected: &'static str) -> DeserializeError {
+    DeserializeError::custom(format!(
+        "corrupted tape: {} value is missing its {expected}",
+        kind_name(value.kind())
+    ))
+}
+
+fn string_value<'de>(value: Value<'de>) -> Result<&'de str> {
+    value
+        .as_str()
+        .ok_or_else(|| invalid_tape(value, "string payload"))
+}
+
+fn i64_value(value: Value<'_>) -> Result<i64> {
+    value
+        .as_i64()
+        .ok_or_else(|| invalid_tape(value, "i64 payload"))
+}
+
+fn u64_value(value: Value<'_>) -> Result<u64> {
+    value
+        .as_u64()
+        .ok_or_else(|| invalid_tape(value, "u64 payload"))
+}
+
+fn f64_value(value: Value<'_>) -> Result<f64> {
+    value
+        .as_f64()
+        .ok_or_else(|| invalid_tape(value, "f64 payload"))
+}
+
+fn bool_value(value: Value<'_>) -> Result<bool> {
+    value
+        .as_bool()
+        .ok_or_else(|| invalid_tape(value, "boolean payload"))
+}
+
+fn container_len(value: Value<'_>) -> Result<usize> {
+    value
+        .len()
+        .ok_or_else(|| invalid_tape(value, "container length"))
+}
+
+impl<'de> de::Deserializer<'de> for Value<'de> {
+    type Error = DeserializeError;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        match self.kind() {
+            ValueKind::Object => visitor.visit_map(ObjectAccess::new(self)?),
+            ValueKind::Array => visitor.visit_seq(ArrayAccess::new(self)?),
+            ValueKind::String => visitor.visit_borrowed_str(string_value(self)?),
+            ValueKind::Int64 => visitor.visit_i64(i64_value(self)?),
+            ValueKind::UInt64 => visitor.visit_u64(u64_value(self)?),
+            ValueKind::Double => visitor.visit_f64(f64_value(self)?),
+            ValueKind::Bool => visitor.visit_bool(bool_value(self)?),
+            ValueKind::Null => visitor.visit_unit(),
+        }
+    }
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        if self.is_null() {
+            visitor.visit_none()
+        } else {
+            visitor.visit_some(self)
+        }
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        if self.is_null() {
+            visitor.visit_unit()
+        } else {
+            Err(invalid_type(self, "null"))
+        }
+    }
+
+    fn deserialize_unit_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_unit(visitor)
+    }
+
+    fn deserialize_newtype_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        if self.kind() == ValueKind::Array {
+            visitor.visit_seq(ArrayAccess::new(self)?)
+        } else {
+            Err(invalid_type(self, "array"))
+        }
+    }
+
+    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        if self.kind() == ValueKind::Object {
+            visitor.visit_map(ObjectAccess::new(self)?)
+        } else {
+            Err(invalid_type(self, "object"))
+        }
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_map(visitor)
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        match self.kind() {
+            ValueKind::String => visitor.visit_enum(string_value(self)?.into_deserializer()),
+            ValueKind::Object => {
+                if self.len() != Some(1) {
+                    return Err(DeserializeError::custom(
+                        "invalid enum: expected an object with exactly one variant key",
+                    ));
+                }
+                let (variant, value) = self.entries().next().ok_or_else(|| {
+                    DeserializeError::custom(
+                        "corrupted tape: enum object reports one variant but has no entries",
+                    )
+                })?;
+                visitor.visit_enum(ExternalEnum { variant, value })
+            }
+            _ => Err(invalid_type(self, "string or single-key object")),
+        }
+    }
+
+    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        if let Some(s) = self.as_str() {
+            visitor.visit_borrowed_bytes(s.as_bytes())
+        } else {
+            self.deserialize_seq(visitor)
+        }
+    }
+
+    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        if let Some(s) = self.as_str() {
+            visitor.visit_byte_buf(s.as_bytes().to_vec())
+        } else {
+            self.deserialize_seq(visitor)
+        }
+    }
+
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        if let Some(s) = self.as_str() {
+            visitor.visit_borrowed_str(s)
+        } else {
+            Err(invalid_type(self, "identifier string"))
+        }
+    }
+
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        let _ = self;
+        visitor.visit_unit()
+    }
+
+    ::serde::forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+    }
+}
+
+struct ArrayAccess<'de> {
+    iter: ArrayIter<'de>,
+    remaining: usize,
+}
+
+impl<'de> ArrayAccess<'de> {
+    fn new(value: Value<'de>) -> Result<Self> {
+        Ok(Self {
+            iter: value.elements(),
+            remaining: container_len(value)?,
+        })
+    }
+}
+
+impl<'de> SeqAccess<'de> for ArrayAccess<'de> {
+    type Error = DeserializeError;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        let Some(value) = self.iter.next() else {
+            return Ok(None);
+        };
+        self.remaining = self.remaining.saturating_sub(1);
+        seed.deserialize(value).map(Some)
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(self.remaining)
+    }
+}
+
+struct ObjectAccess<'de> {
+    iter: ObjectIter<'de>,
+    pending_value: Option<Value<'de>>,
+    remaining: usize,
+}
+
+impl<'de> ObjectAccess<'de> {
+    fn new(value: Value<'de>) -> Result<Self> {
+        Ok(Self {
+            iter: value.entries(),
+            pending_value: None,
+            remaining: container_len(value)?,
+        })
+    }
+}
+
+impl<'de> MapAccess<'de> for ObjectAccess<'de> {
+    type Error = DeserializeError;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>>
+    where
+        K: DeserializeSeed<'de>,
+    {
+        let Some((key, value)) = self.iter.next() else {
+            return Ok(None);
+        };
+        self.pending_value = Some(value);
+        self.remaining = self.remaining.saturating_sub(1);
+        seed.deserialize(key.into_deserializer()).map(Some)
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let value = self.pending_value.take().ok_or_else(|| {
+            DeserializeError::custom("serde requested a map value before requesting its key")
+        })?;
+        seed.deserialize(value)
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(self.remaining)
+    }
+}
+
+struct ExternalEnum<'de> {
+    variant: &'de str,
+    value: Value<'de>,
+}
+
+impl<'de> EnumAccess<'de> for ExternalEnum<'de> {
+    type Error = DeserializeError;
+    type Variant = ExternalVariant<'de>;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant)>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let variant = seed.deserialize(self.variant.into_deserializer())?;
+        Ok((variant, ExternalVariant { value: self.value }))
+    }
+}
+
+struct ExternalVariant<'de> {
+    value: Value<'de>,
+}
+
+impl<'de> VariantAccess<'de> for ExternalVariant<'de> {
+    type Error = DeserializeError;
+
+    fn unit_variant(self) -> Result<()> {
+        if self.value.is_null() {
+            Ok(())
+        } else {
+            Err(invalid_type(self.value, "null variant payload"))
+        }
+    }
+
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        seed.deserialize(self.value)
+    }
+
+    fn tuple_variant<V>(self, _len: usize, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.value.deserialize_seq(visitor)
+    }
+
+    fn struct_variant<V>(self, _fields: &'static [&'static str], visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.value.deserialize_map(visitor)
+    }
+}

--- a/src/stage.rs
+++ b/src/stage.rs
@@ -274,7 +274,7 @@ pub struct Stage1Buffers {
     /// continuation byte) at the same offset the reference reports.
     /// Kernels still mask the tail word by `input_len` (defense in depth).
     ///
-    /// The zero-copy path ([`Stage1Buffers::with_external_input`]) instead
+    /// The zero-copy path (`Stage1Buffers::with_external_input`) instead
     /// wraps caller-held page-aligned memory via
     /// [`GpuBuffer::from_page_aligned`]; that caller guarantees the same
     /// space-padding invariant for the tail word.

--- a/src/value.rs
+++ b/src/value.rs
@@ -259,6 +259,22 @@ impl<'doc> Value<'doc> {
         }
     }
 
+    /// The raw stored child count from the open word, saturated at
+    /// [`CONTAINER_COUNT_MAX`] ("this many or more"); `None` for scalars.
+    ///
+    /// Always O(1) — unlike [`len`](Self::len), a saturated count is
+    /// returned as-is instead of triggering a walk for the exact count.
+    /// Used by the serde accessors, which prefer no size hint over a
+    /// pre-walk of huge containers.
+    #[cfg(feature = "serde")]
+    pub(crate) fn raw_container_count(&self) -> Option<u32> {
+        let word = self.word();
+        match tape::tag(word) {
+            TAG_START_OBJECT | TAG_START_ARRAY => Some(tape::container_count(word)),
+            _ => None,
+        }
+    }
+
     /// Deserialize this value into a serde data model.
     ///
     /// The returned value may borrow strings from the backing

--- a/src/value.rs
+++ b/src/value.rs
@@ -258,6 +258,23 @@ impl<'doc> Value<'doc> {
             }
         }
     }
+
+    /// Deserialize this value into a serde data model.
+    ///
+    /// The returned value may borrow strings from the backing
+    /// [`Document`], so that document must outlive any borrowed fields in
+    /// `T`.
+    ///
+    /// # Errors
+    ///
+    /// If this value's shape or scalar values do not match `T`.
+    #[cfg(feature = "serde")]
+    pub fn deserialize<T>(self) -> crate::serde::Result<T>
+    where
+        T: ::serde::Deserialize<'doc>,
+    {
+        crate::serde::from_value(self)
+    }
 }
 
 impl std::fmt::Debug for Value<'_> {

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -223,3 +223,141 @@ fn deserialization_errors_preserve_serde_semantics() {
         "serde must reject out-of-range numbers"
     );
 }
+
+#[test]
+fn map_keys_parse_for_integer_bool_and_newtype_targets() {
+    let parser = common::cpu_parser();
+
+    let by_id: BTreeMap<u32, String> = parser
+        .parse_deserialize(br#"{"1":"a","2":"b"}"#)
+        .expect("integer-keyed map");
+    assert_eq!(
+        by_id,
+        BTreeMap::from([(1, "a".to_owned()), (2, "b".to_owned())])
+    );
+
+    let negative: BTreeMap<i64, u8> = parser
+        .parse_deserialize(br#"{"-7":1}"#)
+        .expect("signed integer key");
+    assert_eq!(negative, BTreeMap::from([(-7, 1)]));
+
+    let by_flag: BTreeMap<bool, i64> = parser
+        .parse_deserialize(br#"{"true":1,"false":0}"#)
+        .expect("bool-keyed map");
+    assert_eq!(by_flag, BTreeMap::from([(true, 1), (false, 0)]));
+
+    #[derive(Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+    struct Id(String);
+
+    let by_newtype: BTreeMap<Id, u8> = parser
+        .parse_deserialize(br#"{"a":1}"#)
+        .expect("newtype-keyed map");
+    assert_eq!(by_newtype, BTreeMap::from([(Id("a".to_owned()), 1)]));
+
+    // Unparseable keys still hit the target type's own error.
+    assert!(
+        parser
+            .parse_deserialize::<BTreeMap<u32, u8>>(br#"{"x":1}"#)
+            .is_err(),
+        "non-numeric key must not deserialize as u32"
+    );
+}
+
+#[test]
+fn structs_accept_positional_arrays() {
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Point {
+        x: u8,
+        y: u8,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    enum Shape {
+        Vertex { x: u8, y: u8 },
+    }
+
+    let parser = common::cpu_parser();
+
+    let point: Point = parser
+        .parse_deserialize(b"[1,2]")
+        .expect("positional struct");
+    assert_eq!(point, Point { x: 1, y: 2 });
+
+    let vertex: Shape = parser
+        .parse_deserialize(br#"{"Vertex":[3,4]}"#)
+        .expect("positional struct variant");
+    assert_eq!(vertex, Shape::Vertex { x: 3, y: 4 });
+
+    let err = parser
+        .parse_deserialize::<Point>(br#""nope""#)
+        .expect_err("string is not a struct");
+    assert!(
+        err.to_string().contains("expected object or array"),
+        "unexpected struct error: {err}"
+    );
+}
+
+#[test]
+fn tuples_reject_arrays_with_extra_elements() {
+    let parser = common::cpu_parser();
+
+    let pair: (i64, i64) = parser.parse_deserialize(b"[1,2]").expect("exact tuple");
+    assert_eq!(pair, (1, 2));
+
+    let err = parser
+        .parse_deserialize::<(i64, i64)>(b"[1,2,3]")
+        .expect_err("extra elements must not be dropped");
+    assert!(
+        err.to_string()
+            .contains("invalid length 3, expected fewer elements in array"),
+        "unexpected tuple error: {err}"
+    );
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Pair(i64, i64);
+
+    assert!(
+        parser.parse_deserialize::<Pair>(b"[1,2,3]").is_err(),
+        "tuple structs must also reject extra elements"
+    );
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    enum E {
+        T(i64, i64),
+    }
+
+    assert!(
+        parser.parse_deserialize::<E>(br#"{"T":[1,2,3]}"#).is_err(),
+        "tuple variants must also reject extra elements"
+    );
+}
+
+#[test]
+fn i128_u128_exact_within_u64_range_and_error_beyond() {
+    let parser = common::cpu_parser();
+
+    // Exact through u64::MAX — no precision loss above 2^53.
+    let above_2_53: u128 = parser
+        .parse_deserialize(b"9007199254740995")
+        .expect("u128 above 2^53");
+    assert_eq!(above_2_53, 9_007_199_254_740_995);
+
+    let max: u128 = parser
+        .parse_deserialize(b"18446744073709551615")
+        .expect("u128 at u64::MAX");
+    assert_eq!(max, u64::MAX as u128);
+
+    let min: i128 = parser
+        .parse_deserialize(b"-9223372036854775808")
+        .expect("i128 at i64::MIN");
+    assert_eq!(min, i64::MIN as i128);
+
+    // Beyond u64::MAX the tape holds an f64, which 128-bit targets reject.
+    let err = parser
+        .parse_deserialize::<u128>(b"18446744073709551616")
+        .expect_err("beyond-u64 integers were stored as f64");
+    assert!(
+        err.to_string().contains("invalid type: floating point"),
+        "unexpected u128 error: {err}"
+    );
+}

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -295,6 +295,25 @@ fn structs_accept_positional_arrays() {
         err.to_string().contains("expected object or array"),
         "unexpected struct error: {err}"
     );
+
+    // Positional inputs are exact-arity, like tuples: extras are rejected,
+    // not silently dropped.
+    let err = parser
+        .parse_deserialize::<Point>(b"[1,2,3]")
+        .expect_err("extra positional struct field");
+    assert!(
+        err.to_string()
+            .contains("invalid length 3, expected fewer elements in array"),
+        "unexpected extra-element error: {err}"
+    );
+    let err = parser
+        .parse_deserialize::<Shape>(br#"{"Vertex":[3,4,5]}"#)
+        .expect_err("extra positional struct-variant field");
+    assert!(
+        err.to_string()
+            .contains("invalid length 3, expected fewer elements in array"),
+        "unexpected extra-element error: {err}"
+    );
 }
 
 #[test]

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,0 +1,225 @@
+#![cfg(all(feature = "cpu-reference", feature = "serde"))]
+
+mod common;
+
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct BorrowedUser<'a> {
+    id: u64,
+    name: &'a str,
+    active: bool,
+    score: Option<f64>,
+    #[serde(borrow)]
+    tags: Vec<&'a str>,
+    #[serde(borrow)]
+    nested: Nested<'a>,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct Nested<'a> {
+    label: &'a str,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct OwnedConfig {
+    name: String,
+    retries: u8,
+    enabled: bool,
+    limits: Vec<u16>,
+    metadata: BTreeMap<String, i64>,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+enum Event<'a> {
+    Unit,
+    Newtype(u64),
+    Tuple(u8, &'a str),
+    Struct { ok: bool },
+}
+
+#[test]
+fn document_deserializes_borrowed_struct() {
+    let parser = common::cpu_parser();
+    let doc = parser
+        .parse(
+            br#"{
+                "id": 18446744073709551615,
+                "name": "Ada\nLovelace",
+                "active": true,
+                "score": null,
+                "tags": ["gpu", "json"],
+                "nested": { "label": "borrowed" }
+            }"#,
+        )
+        .expect("valid JSON");
+
+    let user: BorrowedUser<'_> = doc.deserialize().expect("serde struct");
+    assert_eq!(
+        user,
+        BorrowedUser {
+            id: u64::MAX,
+            name: "Ada\nLovelace",
+            active: true,
+            score: None,
+            tags: vec!["gpu", "json"],
+            nested: Nested { label: "borrowed" },
+        }
+    );
+}
+
+#[test]
+fn parser_parse_deserialize_returns_owned_struct() {
+    let parser = common::cpu_parser();
+    let config: OwnedConfig = parser
+        .parse_deserialize(
+            br#"{
+                "name": "worker",
+                "retries": 3,
+                "enabled": false,
+                "limits": [1, 255, 1024],
+                "metadata": { "a": -1, "b": 2 }
+            }"#,
+        )
+        .expect("owned serde struct");
+
+    assert_eq!(
+        config,
+        OwnedConfig {
+            name: "worker".to_owned(),
+            retries: 3,
+            enabled: false,
+            limits: vec![1, 255, 1024],
+            metadata: BTreeMap::from([("a".to_owned(), -1), ("b".to_owned(), 2)]),
+        }
+    );
+}
+
+#[test]
+fn value_deserializes_subtrees_and_enums() {
+    let parser = common::cpu_parser();
+    let doc = parser
+        .parse(
+            br#"{
+                "limits": [8, 16, 32],
+                "unit": "Unit",
+                "newtype": { "Newtype": 42 },
+                "tuple": { "Tuple": [7, "seven"] },
+                "struct": { "Struct": { "ok": true } }
+            }"#,
+        )
+        .expect("valid JSON");
+    let root = doc.root();
+
+    let limits: Vec<u16> = root
+        .get("limits")
+        .expect("limits")
+        .deserialize()
+        .expect("limits subtree");
+    assert_eq!(limits, vec![8, 16, 32]);
+
+    let unit: Event<'_> = root
+        .get("unit")
+        .expect("unit")
+        .deserialize()
+        .expect("unit enum");
+    let newtype: Event<'_> = root
+        .get("newtype")
+        .expect("newtype")
+        .deserialize()
+        .expect("newtype enum");
+    let tuple: Event<'_> = root
+        .get("tuple")
+        .expect("tuple")
+        .deserialize()
+        .expect("tuple enum");
+    let structure: Event<'_> = root
+        .get("struct")
+        .expect("struct")
+        .deserialize()
+        .expect("struct enum");
+
+    assert_eq!(unit, Event::Unit);
+    assert_eq!(newtype, Event::Newtype(42));
+    assert_eq!(tuple, Event::Tuple(7, "seven"));
+    assert_eq!(structure, Event::Struct { ok: true });
+}
+
+#[test]
+fn root_scalars_and_interior_nul_strings_deserialize() {
+    let parser = common::cpu_parser();
+
+    let none: Option<u8> = parser
+        .parse(b"null")
+        .expect("null parses")
+        .deserialize()
+        .expect("option");
+    assert_eq!(none, None);
+
+    let flag: bool = parser
+        .parse(b"true")
+        .expect("bool parses")
+        .deserialize()
+        .expect("bool");
+    assert!(flag);
+
+    let signed: i64 = parser
+        .parse(b"-42")
+        .expect("i64 parses")
+        .deserialize()
+        .expect("i64");
+    assert_eq!(signed, -42);
+
+    let unsigned: u64 = parser
+        .parse(b"18446744073709551615")
+        .expect("u64 parses")
+        .deserialize()
+        .expect("u64");
+    assert_eq!(unsigned, u64::MAX);
+
+    let negative_zero: f64 = parser
+        .parse(b"-0.0")
+        .expect("double parses")
+        .deserialize()
+        .expect("f64");
+    assert_eq!(negative_zero.to_bits(), (-0.0f64).to_bits());
+
+    let doc = parser
+        .parse(br#""a\u0000b""#)
+        .expect("interior NUL string parses");
+    let borrowed: &str = doc.deserialize().expect("borrowed string");
+    assert_eq!(borrowed.as_bytes(), b"a\0b");
+}
+
+#[test]
+fn deserialization_errors_preserve_serde_semantics() {
+    let parser = common::cpu_parser();
+
+    let duplicate = parser.parse(br#"{"k":1,"k":2}"#).expect("valid JSON");
+    let err = duplicate
+        .deserialize::<BTreeMap<String, i64>>()
+        .expect("maps may consume duplicate keys with last-write-wins");
+    assert_eq!(err.get("k"), Some(&2));
+
+    #[allow(dead_code)]
+    #[derive(Debug, Deserialize)]
+    struct Single {
+        k: i64,
+    }
+
+    let err = duplicate
+        .deserialize::<Single>()
+        .expect_err("duplicate field");
+    assert!(
+        err.to_string().contains("duplicate field"),
+        "unexpected duplicate-field error: {err}"
+    );
+
+    let too_large = parser.parse(b"256").expect("valid JSON");
+    assert!(
+        too_large.deserialize::<u8>().is_err(),
+        "serde must reject out-of-range numbers"
+    );
+}


### PR DESCRIPTION
## What

Adds a `serde` feature: a `serde::Deserializer` over the tape/string buffers a `Parser` already produced. No JSON text parsing in this layer — it materializes Rust data models from the parsed `Document`, borrowing strings zero-copy when `T` has `&str` fields.

```
JSON bytes ──GPU──▶ tape + unescaped strings ──serde walk──▶ T
                                              (this PR)
```

New API (all behind `feature = "serde"`):
- `Document::deserialize::<T>()` / `Value::deserialize::<T>()` — `T` may borrow from the document
- `Parser::parse_deserialize::<T>()` — owned convenience path
- `metal_json::serde::{from_document, from_value, DeserializeError}`

## serde_json parity (each reviewed adversarially, each pinned by a test)

- Zero-copy borrowed map keys (`BTreeMap<&str, _>`), plus integer / bool / newtype map-key targets parsed from key text
- Structs and struct variants accept positional JSON arrays
- Tuples reject arrays with extra elements, same error wording as serde_json
- Externally tagged enums in all four variant shapes; `Option`, unit, newtype, bytes
- Documented divergence: integers beyond i64/u64 range were stored as f64 at parse time (same as simdjson), so i128/u128 targets reject them — unlike serde_json's full 128-bit parsing

## Perf

- Ignored fields skip in O(1) via the tape's container end-index payload
- Direct scalar fast paths (one tag check), exact `size_hint` counting down per item, and no O(n) pre-walk for saturated container counts
- New bench `bench/benches/serde_compare.rs` (deterministic ~4 MiB synthetic corpus, checksum-verified equivalence before timing):

| contender | throughput |
|---|---|
| serde_json borrowed | ~972 MiB/s |
| serde_json owned | ~614 MiB/s |
| metal-json borrowed (GPU) | ~384 MiB/s |
| metal-json owned (GPU) | ~349 MiB/s |

Honest note: at 4 MiB the GPU dispatch overhead dominates and serde_json wins end-to-end; large documents remain the design point. `METAL_JSON_BENCH_BACKEND` and a larger corpus size give other operating points.

## Verification

- 251 unit + all integration suites green on `cpu-reference,serde`; GPU e2e green locally
- clippy (workspace, all targets) and rustdoc: zero warnings
- `size_hint` bookkeeping pinned by hand-built saturated-count tapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)